### PR TITLE
[Feat] Implement View Config in new tab

### DIFF
--- a/src/app/designer.controller.js
+++ b/src/app/designer.controller.js
@@ -150,6 +150,12 @@ angular
                 return;
             }
 
+            if (event.ctrlKey && event.key === 'e') {
+                event.preventDefault();
+                $rootScope.viewConfig();
+                return;
+            }
+
             if (!($rootScope.hasLocalSaveSupport())) return;
 
             if (event.ctrlKey && event.key === 'o') {
@@ -187,6 +193,22 @@ angular
 
             var date = new Date().getTime();
             downloadDocument("krakend.json", angular.toJson(save, true)); // Beautify
+            $rootScope.saved_once = true;
+        };
+
+        $rootScope.viewConfig = function () {
+            $rootScope.fixCipherSuitesType('auth/signer', false);
+            $rootScope.fixCipherSuitesType('auth/validator', false);
+
+            // Make a copy of the service and clean it, do not modify rootScope!
+            save = angular.copy($rootScope.service);
+            cleanServiceForSaving(save)
+
+            // open new tab with the json preview pretty printed
+            var newWindow = window.open();
+            if (newWindow.document) {
+                newWindow.document.write('<pre>' + angular.toJson(save, true) + '</pre>');
+            }
             $rootScope.saved_once = true;
         };
 

--- a/src/app/layout/layout.html
+++ b/src/app/layout/layout.html
@@ -77,6 +77,11 @@
               <i class="fa fa-copy"></i> Download config <samp class="small">(^D)</samp>
             </button>
           </li>
+          <li class="text-center">
+            <button id="viewConfig" name="viewConfig" class="btn btn-toolbar center-block" ng-click="viewConfig()">
+              <i class="fa fa-eye"></i> View config <samp class="small">(^E)</samp>
+            </button>
+          </li>
           </ul>
         </div>
       </nav>


### PR DESCRIPTION
This is a Feature to allow user to View/Preview the changes in json config file without needing to download it everytime.
🎉🎉 It always easier to just preview, and copy what we need rather than download the whole file!

- New button added to the most right 
![image](https://github.com/krakend/krakendesigner/assets/7235788/4dda1bb8-2122-4618-aa39-1f0fa60a8b49)

- The new tab open with generated json file
![image](https://github.com/krakend/krakendesigner/assets/7235788/bb133e3c-2c1c-431b-ba8b-8257a9b51936)
